### PR TITLE
changing the default value of the keep shapes argument

### DIFF
--- a/src/main/scala/es/weso/wdsub/spark/SparkJobConfig.scala
+++ b/src/main/scala/es/weso/wdsub/spark/SparkJobConfig.scala
@@ -14,7 +14,7 @@ class SparkJobConfig(arguments: Seq[String]) extends ScallopConf(arguments) with
   val jobInputDump = opt[String](required = true, name = "dump", descr = "Select the input dump by entering the path")
   val jobInputSchema = opt[String](required = true, name = "schema", descr = "Select the input schema by entering the path")
   val jobOutputDir = opt[String](required = true, name = "out", descr = "Select the output directory. Please remove the trailing slash")
-  val keepShapes = opt[Boolean](required = false, default = Some(true), name = "keep_shapes", descr = "Show the shapes")
+  val keepShapes = opt[Boolean](required = false, default = Some(false), name = "keep_shapes", descr = "Show the shapes")
   val keepErrors = opt[Boolean](required = false, default = Some(false), name = "keep_errors", descr = "Keep errors during validation")
 
   printHelp()


### PR DESCRIPTION
The keep shapes parameter doesn't take any argument, it just seems to include shape debug information if it's present, or omit it if the parameter isn't present. But the parameter's default value is set to true, so there doesn't seem to be any way to turn this off. With this change there is no shape information when the argument isn't present and shape information when it is.